### PR TITLE
Allow units to be combined with coefficient in one argument

### DIFF
--- a/man1/uconv.1
+++ b/man1/uconv.1
@@ -10,6 +10,9 @@ uconv \- a general-purpose unit converter
 .SH SYNOPSIS
 .B uconv 
 .RB [options]\ {value}\ {from_units}\ {to_units} 
+
+.B uconv
+.RB [options]\ \-c\ {value}{from_units}\ {to_units}
 .PP
 
 .SH DESCRIPTION
@@ -48,6 +51,12 @@ For example, to convert 6 feet to centimetres:
 
 .nf
 uconv 6 ft cm
+.fi
+
+Or:
+
+.nf
+uconv -c 6ft cm
 .fi
 
 However, because \fIuconv\fR recognizes a large number of synonyms for 
@@ -287,6 +296,9 @@ The unit 'mpg', which is a shortcut for 'miles/gallon' refers to the UK
 .TP
 .BI -h
 Show brief usage information 
+.TP
+.BI -c
+Allow the units to be combined with the coefficient as one argument.
 .LP
 .TP
 .BI -l

--- a/man1/uconv.1
+++ b/man1/uconv.1
@@ -8,11 +8,11 @@
 .SH NAME
 uconv \- a general-purpose unit converter 
 .SH SYNOPSIS
+.B uconv
+.RB [options]\ {value}{from_units}\ {to_units}
+
 .B uconv 
 .RB [options]\ {value}\ {from_units}\ {to_units} 
-
-.B uconv
-.RB [options]\ \-c\ {value}{from_units}\ {to_units}
 .PP
 
 .SH DESCRIPTION
@@ -39,6 +39,10 @@ consistent, and \fIuconv\fR will invert the result according. So, for example,
 it can convert miles/gallon to litres/km, even though these units are
 complementary, rather than equivalent. 
 
+Although the examples in this manual are shown using 3 arguments -- one for the
+number, one for its units and the destination units -- the units can also be
+specified in the same argument as the coefficient.
+
 .SH OVERVIEW OF OPERATION
 
 The basic command is:
@@ -47,16 +51,22 @@ The basic command is:
 uconv {value} {from_units} {to_units}
 .fi
 
+Or, for the two argument form:
+
+.nf
+uconv {value}{from_units} {to_units}
+.fi
+
 For example, to convert 6 feet to centimetres:
 
 .nf
 uconv 6 ft cm
 .fi
 
-Or:
+And the equivalent two-argument form:
 
 .nf
-uconv -c 6ft cm
+uconv 6ft cm
 .fi
 
 However, because \fIuconv\fR recognizes a large number of synonyms for 
@@ -296,9 +306,6 @@ The unit 'mpg', which is a shortcut for 'miles/gallon' refers to the UK
 .TP
 .BI -h
 Show brief usage information 
-.TP
-.BI -c
-Allow the units to be combined with the coefficient as one argument.
 .LP
 .TP
 .BI -l

--- a/uconv.c
+++ b/uconv.c
@@ -145,7 +145,7 @@ int main (int argc, char **argv)
   if (invalid)
     {
     fprintf (stderr, "%s: %s\n", invalid,
-      errno == 0 ? "not a valid number" : strerror(errno));
+      errno == 0 ? "Not a valid number" : strerror(errno));
     return 1;
     }
 

--- a/uconv.c
+++ b/uconv.c
@@ -32,7 +32,9 @@ void show_version (void)
 void show_usage (const char *argv0, FILE *out)
   {
   fprintf (out, "Usage: %s [options] {number} {from_units} {to_units}\n", argv0);
+  fprintf (out, "       %s [options] -c {number}{from_units} {to_units}\n", argv0);
   fprintf (out, "Options:\n");
+  fprintf (out, "  -c                Allow units to be combined with number\n");
   fprintf (out, "  -d                Force decimal output\n");
   fprintf (out, "  -h                Show this message\n");
   fprintf (out, "  -l                List available units\n");

--- a/uconv.c
+++ b/uconv.c
@@ -121,6 +121,11 @@ int main (int argc, char **argv)
         invalid = argv[optind];
         if (from != argv[optind]) *from = '\0'; // Don't include units in error.
         }
+      else if (*from == '\0')
+        {
+        fprintf (stderr, "%s: Missing destination units\n", argv[0]);
+        return 1;
+        }
       break;
     case 3:
       from = argv[optind + 1];

--- a/uconv.c
+++ b/uconv.c
@@ -131,7 +131,7 @@ int main (int argc, char **argv)
     {
     to = argv[optind + 1];
     errno = 0;
-    n = strtod(argv[optind], &from);
+    n = strtod (argv[optind], &from);
     if (errno != 0 || from == argv[optind])
       {
       invalid = argv[optind];


### PR DESCRIPTION
This change lets the user combine the units with the coefficient instead of requiring them to being specified as separate arguments. In implementing this, the existing error handling was modified so the program terminates with a non-zero status in the event of an error, and it also tries to give a more descriptive error when parsing values.