### PR TITLE
Remove unportable malloc.h header

### DIFF
--- a/uconv.c
+++ b/uconv.c
@@ -7,7 +7,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <malloc.h>
 #include <string.h>
 #include <ctype.h>
 #include "units.h" 

--- a/units.c
+++ b/units.c
@@ -7,7 +7,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <malloc.h>
 #include <ctype.h>
 #include <stdlib.h>
 #include <math.h>


### PR DESCRIPTION
The malloc.h header is non-standard, and the program does not make use of any unportable functions that might be defined in the header. After removing this header, uconv can be compiled on the latest release of macOS with no other changes.